### PR TITLE
Add test for entire pipeline

### DIFF
--- a/butterfly/tests/test_pipeline.py
+++ b/butterfly/tests/test_pipeline.py
@@ -1,0 +1,37 @@
+import subprocess
+import os
+
+import pytest
+
+
+@pytest.mark.timeout(60)
+def test_main():
+
+    test_input_dir = "butterfly/tests/test_files/test_input/"
+    test_output_dir = "butterfly/tests/test_files/test_output/"
+    test_command = "python pipeline.py -p -i " + test_input_dir \
+                    + " -o " + test_output_dir \
+                    + " -s measurements -csv " + test_output_dir \
+                    + "test_results.csv"
+
+    # testing is done by calling the pipeline.py file with the test_command
+    subprocess.call(test_command.split())
+
+    files_in_test_output = os.listdir(test_output_dir)
+    output_image, output_csv = "", ""
+
+    for file in files_in_test_output:
+        if file.lower().endswith(('.png', '.jpg', '.jpeg')):
+            output_image = file
+        if file.lower().endswith('.csv'):
+            output_csv = files_in_test_output
+
+    # some more testing functions can go here,
+    # for example checking the contents
+
+    # removing the output files from our pipeline run
+    for file in files_in_test_output:
+        os.remove(test_output_dir + file)
+
+    # assert the two outputs exist
+    assert(output_image and output_csv)

--- a/butterfly/tests/test_pipeline.py
+++ b/butterfly/tests/test_pipeline.py
@@ -1,37 +1,43 @@
 import subprocess
 import os
+import shutil
 
 import pytest
 
 
-@pytest.mark.timeout(60)
-def test_main():
+TIMEOUT_TIME = 60
 
-    test_input_dir = "butterfly/tests/test_files/test_input/"
-    test_output_dir = "butterfly/tests/test_files/test_output/"
-    test_command = "python pipeline.py -p -i " + test_input_dir \
-                    + " -o " + test_output_dir \
-                    + " -s measurements -csv " + test_output_dir \
-                    + "test_results.csv"
+
+@pytest.mark.timeout(TIMEOUT_TIME)
+def test_pipeline_main():
+
+    test_input_dir = 'butterfly/tests/test_files/test_input/'
+    test_output_dir = 'butterfly/tests/test_files/test_output/'
+    test_command = [
+        'python', 'pipeline.py', '-p',
+        '-i', test_input_dir,
+        '-o', test_output_dir,
+        '-s', 'measurements',
+        '-csv', test_output_dir + 'test_results.csv'
+    ]
 
     # testing is done by calling the pipeline.py file with the test_command
-    subprocess.call(test_command.split())
+    subprocess.check_call(test_command)
 
     files_in_test_output = os.listdir(test_output_dir)
-    output_image, output_csv = "", ""
+    output_image, output_csv = '', ''
 
-    for file in files_in_test_output:
-        if file.lower().endswith(('.png', '.jpg', '.jpeg')):
-            output_image = file
-        if file.lower().endswith('.csv'):
+    for f in files_in_test_output:
+        if f.lower().endswith(('.png', '.jpg', '.jpeg')):
+            output_image = f
+        if f.lower().endswith('.csv'):
             output_csv = files_in_test_output
 
     # some more testing functions can go here,
     # for example checking the contents
 
-    # removing the output files from our pipeline run
-    for file in files_in_test_output:
-        os.remove(test_output_dir + file)
+    # removing the test output directory from our pipeline run
+    shutil.rmtree(test_output_dir)
 
     # assert the two outputs exist
     assert(output_image and output_csv)


### PR DESCRIPTION
Implemented basic version of test_pipeline that runs the pipeline via subprocess and checks to see if the outputs exist. Included a test image

Should probably check the contents of each file and validate that as well.

Requires pytest plugin called pytest-timeout. This is to create timeout error if pipeline call takes longer than a minute