### PR TITLE
Ignoring non image input

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -93,7 +93,7 @@ def main():
     for i, image_name in enumerate(image_names):
 
         # if input is not an image, continue
-        if not f.lower().endswith(('.png', '.jpg', '.jpeg')):
+        if not image_name.lower().endswith(('.png', '.jpg', '.jpeg')):
             continue
 
         print(f'Image {i+1}/{n} : {image_name}')

--- a/pipeline.py
+++ b/pipeline.py
@@ -89,8 +89,13 @@ def main():
         image_names = [""]
     n = len(image_names)
 
-    # For testing purpose, the pipeline is only applied to the first 10 images
+    
     for i, image_name in enumerate(image_names):
+
+        # if input is not an image, continue
+        if not f.lower().endswith(('.png', '.jpg', '.jpeg')):
+            continue
+
         print(f'Image {i+1}/{n} : {image_name}')
         image_path = os.path.normpath(raw_image_path + '/' + image_name)
         image_rgb = imread(image_path)


### PR DESCRIPTION
Fixing issue with pipeline crashing if encountering a file in input directory that is not an image