### PR TITLE
Binarize tags finding fix

### DIFF
--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -50,13 +50,13 @@ def find_tags_edge(binary, top_ruler):
     for r in regions:
         rotated_axes_area = r.major_axis_length * r.minor_axis_length
         rotated_extent = r.area / rotated_axes_area
-        if rotated_extent > EXTENT_TOLERANCE and r.orientation < ORIENTATION_TOLERANCE:
+        if rotated_extent > EXTENT_TOLERANCE and abs(r.orientation) < ORIENTATION_TOLERANCE:
             filtered_regions.append(r)
         if len(filtered_regions) >= NUM_TAG_REGIONS:
             break
     
     left_sides = [r.bbox[1] for r in filtered_regions]
-    crop_right = int(0.5 * binary.shape[1] + np.min(left_sides))
+    crop_right = int(0.5 * binary.shape[1]) + np.min(left_sides) - 1
     
     return crop_right
 

--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -4,6 +4,7 @@ from scipy import ndimage as ndi
 from skimage.measure import regionprops
 import skimage.color as color
 from skimage.exposure import rescale_intensity
+from skimage.morphology import binary_erosion
 from joblib import Memory
 location = './cachedir'
 memory = Memory(location, verbose=0)
@@ -26,28 +27,26 @@ def find_tags_edge(binary, top_ruler):
         x coordinate of the vertical line separating the tags area from the
         butterfly area
     """
-    lower_bound = top_ruler - int(binary.shape[0] * 0.1)
+    lower_bound = top_ruler
     left_bound = int(binary.shape[1] * 0.5)
     focus = binary[:lower_bound, left_bound:]
-
-    markers = ndi.label(focus,
+    
+    focus_filled = ndi.binary_fill_holes(focus)
+    focus_filled_eroded = binary_erosion(focus_filled)
+    
+    
+    markers = ndi.label(focus_filled_eroded,
                         structure=ndi.generate_binary_structure(2, 1))[0]
     
     regions = regionprops(markers)
-    biggest_areas = [(i, region.area) for i, region in enumerate(regions)]
-    biggest_areas.sort(key=lambda x: x[1], reverse=True)
+    regions.sort(key=lambda r: r.bbox[3], reverse=True)
+    regions.sort(key=lambda r: r.area, reverse=True)
     
-    filtered_regions = []
-    for i, area in biggest_areas[1:5]:
-        if regions[i].extent>0.8:
-            filtered_regions.append(regions[i])
-
-    left_pixels = [np.min(region.coords[:, 1]) for region in filtered_regions]
-    left_pixels = np.array(left_pixels)
-    left_pixels = left_pixels[left_pixels > 0.05 * binary.shape[1]]
-
-    crop_right = int(0.5 * binary.shape[1] + np.min(left_pixels))
-
+    filtered_regions = regions[:3]
+    
+    left_sides = [r.bbox[1] for r in filtered_regions]
+    crop_right = int(0.5 * binary.shape[1] + np.min(left_sides))
+    
     return crop_right
 
 

--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -55,8 +55,8 @@ def find_tags_edge(binary, top_ruler):
         if len(filtered_regions) >= NUM_TAG_REGIONS:
             break
     
-    left_sides = [r.bbox[1] for r in filtered_regions]
-    crop_right = int(0.5 * binary.shape[1]) + np.min(left_sides) - 1
+    left_sides = [r.bbox[1] for r in filtered_regions] + [focus.shape[1]]
+    crop_right = left_bound + np.min(left_sides) - 1
     
     return crop_right
 

--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -32,12 +32,14 @@ def find_tags_edge(binary, top_ruler):
 
     markers = ndi.label(focus,
                         structure=ndi.generate_binary_structure(2, 1))[0]
+    
     regions = regionprops(markers)
-    areas = [region.area for region in regions]
-    area_min = 0.01 * binary.shape[0] * binary.shape[1]
+    biggest_areas = [(i, region.area) for i, region in enumerate(regions)]
+    biggest_areas.sort(key=lambda x: x[1], reverse=True)
+    
     filtered_regions = []
-    for i, area in enumerate(areas):
-        if area > area_min:
+    for i, area in biggest_areas[1:5]:
+        if regions[i].extent>0.8:
             filtered_regions.append(regions[i])
 
     left_pixels = [np.min(region.coords[:, 1]) for region in filtered_regions]

--- a/butterfly/tests/test_binarization.py
+++ b/butterfly/tests/test_binarization.py
@@ -29,11 +29,40 @@ def fake_butterfly_layout():
 
     return binary, (bfly_height, bfly_width)
 
+@pytest.fixture(scope="module")
+def fake_butterfly_no_tags():
+    M, N = (300, 400)
+
+    binary = np.zeros((M, N))
+    binary[230:] = 1  # ruler
+
+    # "butterfly"
+    bfly_upper, bfly_lower = 50, 180
+    bfly_left, bfly_right = 50, 220
+    bfly_height = bfly_lower - bfly_upper
+    bfly_width = bfly_right - bfly_left
+
+    rr, cc = draw.polygon(
+        [bfly_upper, bfly_upper, bfly_lower],
+        [bfly_left, bfly_right, (bfly_left + bfly_right) / 2]
+    )
+    binary[rr, cc] = 1
+
+    return binary, (bfly_height, bfly_width)
+
 
 def test_find_tags_edge(fake_butterfly_layout):
     butterfly, (rows, cols) = fake_butterfly_layout
     result = binarization.find_tags_edge(butterfly, 230)
     assert (250 <= result <= 260)  # assert the tags edge is in a proper place
+
+
+def test_missing_tags(fake_butterfly_no_tags):
+    butterfly, (rows, cols) = fake_butterfly_no_tags
+    result = binarization.find_tags_edge(butterfly, 230)
+    # such a crop will probably throw off measurement process
+    # but the program won't crash
+    assert (result >= 399)
 
 
 def test_main(fake_butterfly_layout):


### PR DESCRIPTION
Fixes to how labels are found (and used in cropping) during the binarization step
- Previous method was crashing due to labels being rejected by a hard-coded area threshold
- New method checks the largest regions in the image, and selects the 3 that best represent a tag based on the ratio of the area of its bounding box (that is defined by its major and minor axes) to the pixels of the tag. also does other stuff like eroding and hole filling to make this easier