### PR TITLE
Binarize tags finding improved

### DIFF
--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -77,9 +77,10 @@ def find_tags_edge(image_rgb, top_ruler, axes=None):
     max_img_focus_cutoff_regions = [r for r in max_img_focus_regions if r.centroid[1]>cutoff]
 
     # From the remaining regions find their leftmost edge
-    max_img_leftedges = [r.bbox[1] for r in max_img_focus_cutoff_regions]
-    label_edge = np.min(max_img_leftedges)
-    
+    max_img_leftedges = [r.bbox[1] for r in max_img_focus_cutoff_regions] + [max_img.shape[1]]
+    # Binary erosion causes a pixel to be eroded away from the tag edge
+    label_edge = np.min(max_img_leftedges) - 1
+
 
     if axes and axes[6]:
         halfway = img_tags_filled_eroded.shape[1]//2

--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -9,8 +9,16 @@ from joblib import Memory
 location = './cachedir'
 memory = Memory(location, verbose=0)
 
+# Height of a square region used to determine the minimum region size in find_tags_edge.
+# Percent of height of the image.
 MIN_REGION_HEIGHT = 0.05
+
+# Height of extra margin to make sure all of the ruler is cropped out in find_tags_edge.
+# Percent of height of the image
 RULER_CROP_MARGIN = 0.025
+
+# Distance from right-hand edge of the image in which we consider regions to be tags.
+# Used in find_tags_edge. Percent of width of the image
 REGION_CUTOFF = 2/5
 
 def find_tags_edge(image_rgb, top_ruler, axes=None):
@@ -19,7 +27,7 @@ def find_tags_edge(image_rgb, top_ruler, axes=None):
 
     Arguments
     ---------
-    image_rgb : color image
+    image_rgb : (M, N, 3) ndarray
         Full RGB image input image
     top_ruler : int
         Y-coordinate of the top of the ruler

--- a/butterfly/tests/test_binarization.py
+++ b/butterfly/tests/test_binarization.py
@@ -54,13 +54,21 @@ def fake_butterfly_no_tags():
 
 def test_find_tags_edge(fake_butterfly_layout):
     butterfly, (rows, cols) = fake_butterfly_layout
-    result = binarization.find_tags_edge(butterfly, 230)
+    picture_2d = butterfly.astype(np.uint8)
+    picture_3d = np.dstack((picture_2d,
+                            1/2 * picture_2d,
+                            1/4 * picture_2d))  # fake RGB image
+    result = binarization.find_tags_edge(picture_3d, 230)
     assert (250 <= result <= 260)  # assert the tags edge is in a proper place
 
 
 def test_missing_tags(fake_butterfly_no_tags):
     butterfly, (rows, cols) = fake_butterfly_no_tags
-    result = binarization.find_tags_edge(butterfly, 230)
+    picture_2d = butterfly.astype(np.uint8)
+    picture_3d = np.dstack((picture_2d,
+                            1/2 * picture_2d,
+                            1/4 * picture_2d))  # fake RGB image
+    result = binarization.find_tags_edge(picture_3d, 230)
     # such a crop will probably throw off measurement process
     # but the program won't crash
     assert (result >= 399)


### PR DESCRIPTION
New tags finding method should reduce remaining failure cases when tags aren't found properly
- Binarized HSV of butterfly is added to binarized tags to get all relevant regions of image (also used hole filling and erosion)
- Butterfly is then removed, remaining regions are tags, and used to choose the crop region.