### PR TITLE
Add temporary files to current folder instead of /tmp

### DIFF
--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -196,7 +196,7 @@ def unet_binarization(bfly_rgb, weights='./models/segmentation.pkl'):
     learner = load_learner(path=weights.parent, file=weights.name)
 
     print('Processing U-net...')
-    with NamedTemporaryFile(suffix='.png') as aux_fname:
+    with NamedTemporaryFile(suffix='.png', dir='.') as aux_fname:
         imsave(fname=aux_fname.name, arr=img_as_ubyte(bfly_rgb), check_contrast=False)
         bfly_aux = open_image(aux_fname.name)
 

--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -196,7 +196,7 @@ def unet_binarization(bfly_rgb, weights='./models/segmentation.pkl'):
     learner = load_learner(path=weights.parent, file=weights.name)
 
     print('Processing U-net...')
-    with NamedTemporaryFile(suffix='.png', dir='.') as aux_fname:
+    with NamedTemporaryFile(suffix='.png') as aux_fname:
         imsave(fname=aux_fname.name, arr=img_as_ubyte(bfly_rgb), check_contrast=False)
         bfly_aux = open_image(aux_fname.name)
 

--- a/butterfly/identification.py
+++ b/butterfly/identification.py
@@ -49,7 +49,7 @@ def _classification(bfly_rgb, weights):
     # parameters here were defined when training the networks.
     learner = load_learner(path=weights.parent, file=weights.name)
 
-    with NamedTemporaryFile(suffix='.png', dir='.') as aux_fname:
+    with NamedTemporaryFile(suffix='.png') as aux_fname:
         imsave(fname=aux_fname.name, arr=img_as_ubyte(bfly_rgb), check_contrast=False)
         bfly_aux = open_image(aux_fname.name)
 

--- a/butterfly/identification.py
+++ b/butterfly/identification.py
@@ -49,7 +49,7 @@ def _classification(bfly_rgb, weights):
     # parameters here were defined when training the networks.
     learner = load_learner(path=weights.parent, file=weights.name)
 
-    with NamedTemporaryFile(suffix='.png') as aux_fname:
+    with NamedTemporaryFile(suffix='.png', dir='.') as aux_fname:
         imsave(fname=aux_fname.name, arr=img_as_ubyte(bfly_rgb), check_contrast=False)
         bfly_aux = open_image(aux_fname.name)
 


### PR DESCRIPTION
Adding temporary files to current folder, using `NamedTemporaryFile(dir='.')`. Solves:
```
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\Ben\\AppData\\Local\\Temp\\tmp50qh9c64.png'
```